### PR TITLE
Update 02_prepare_package.sh

### DIFF
--- a/scripts/02_prepare_package.sh
+++ b/scripts/02_prepare_package.sh
@@ -173,7 +173,7 @@ svn co https://github.com/coolsnowwolf/lede/trunk/package/lean/luci-app-netdata 
 #svn co https://github.com/vernesong/OpenClash/branches/master/luci-app-openclash package/new/luci-app-openclash
 git clone -b master --single-branch https://github.com/vernesong/OpenClash package/new/luci-app-openclash
 #SeverChan
-git clone -b master --single-branch https://github.com/tty228/luci-app-serverchan package/new/luci-app-serverchan
+git clone -b master --single-branch https://github.com/alecthw/luci-app-serverchan package/new/luci-app-serverchan
 svn co https://github.com/openwrt/openwrt/branches/openwrt-19.07/package/network/utils/iputils package/network/utils/iputils
 #SmartDNS
 svn co https://github.com/pymumu/smartdns/trunk/package/openwrt package/new/smartdns


### PR DESCRIPTION
解决 serverchan 更新后无法编译的问题  后继tty228的仓库合并后可以正常编译可以改回去。